### PR TITLE
Replace strlen with mb_strlen to account for utf8

### DIFF
--- a/acf-input-counter.php
+++ b/acf-input-counter.php
@@ -78,7 +78,7 @@
 				// only run on text and text area fields when maxlength is set
 				return;
 			}
-			$len = strlen($field['value']);
+			$len = mb_strlen($field['value']);
 			$max = $field['maxlength'];
 
 			$classes 	= apply_filters('acf-input-counter/classes', array());


### PR DESCRIPTION
Replace strlen() with mb_strlen() to account for text encoding. 

According to:
"In UTF-8, not all characters are represented with 1 byte. In fact, characters can be represented with as many as 4 bytes in UTF-8. In this example, the character “ä” is represented using 2 bytes in UTF-8, so the strlen() function returns 9 rather than the expected 8."
And: http://php.net/manual/en/function.strlen.php#45407
