### PR TITLE
require composer/installers & some metadatas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,10 @@
     "name": "wpcomposer/acf-input-counter",
     "description": "Adds a counter to all text and textarea fields with character limits",
     "type": "wordpress-plugin",
-    "require": {}
+    "license": "GPL-3.0",
+    "keywords": ["wordpress", "plugin", "acf"],
+    "homepage": "https://github.com/Hube2/acf-input-counter",
+    "require": {
+        "composer/installers": "v1.5.0"
+    }
 }


### PR DESCRIPTION
Requiring composer/installers to allow anyone customizing the install path.

I've added also some metadata :
- the license used with this plugin
- the link to the repo
- keywords