### PR TITLE
Relax version constraint on composer/installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,6 @@
     "keywords": ["wordpress", "plugin", "acf"],
     "homepage": "https://github.com/Hube2/acf-input-counter",
     "require": {
-        "composer/installers": "v1.5.0"
+        "composer/installers": "^1.5.0"
     }
 }


### PR DESCRIPTION
Permits this library to depend on newer versions of `composer/installers`, which makes it possible to use this library alongside other packages that depend on versions of `composer/installers` newer than 1.5.