### PR TITLE
Remove closing php tag

### DIFF
--- a/acf-input-counter.php
+++ b/acf-input-counter.php
@@ -185,4 +185,3 @@
 		}
 	} // end if !function_exists
 
-?>


### PR DESCRIPTION
This plugin was causing some errors for me because of the PHP closing tag and new line at the end of the file.

The new line causes headers to be sent earlier than they should be and results in `Cannot modify header information - headers already sent` when trying to set sessions/cookies etc in theme files.

Edit: See here for more details. I found the issue using the `phptag` cli tool mentioned in this comment.